### PR TITLE
restore previous delegate

### DIFF
--- a/ZoomTransition/ZoomInteractiveTransition.h
+++ b/ZoomTransition/ZoomInteractiveTransition.h
@@ -66,4 +66,9 @@
  */
 - (instancetype)initWithNavigationController:(UINavigationController *)nc;
 
+/**
+ *  Public method to reset the navigation controller's delegate
+ */
+- (void)resetDelegate;
+
 @end

--- a/ZoomTransition/ZoomInteractiveTransition.m
+++ b/ZoomTransition/ZoomInteractiveTransition.m
@@ -29,6 +29,7 @@
 
 @interface ZoomInteractiveTransition()
 
+@property (nonatomic, weak) id <UINavigationControllerDelegate> previousDelegate;
 @property (nonatomic, assign) CGFloat startScale;
 @property (nonatomic, assign) UINavigationControllerOperation operation;
 @property (nonatomic, assign) BOOL shouldCompleteTransition;
@@ -45,10 +46,15 @@
     self.transitionAnimationOption = UIViewKeyframeAnimationOptionCalculationModeCubic;
 }
 
+- (void)resetDelegate {
+    self.navigationController.delegate = self.previousDelegate;
+}
+
 - (instancetype)initWithNavigationController:(UINavigationController *)nc
 {
     if (self = [super init]) {
         self.navigationController = nc;
+        self.previousDelegate = nc.delegate;
         nc.delegate = self;
         [self commonSetup];
     }


### PR DESCRIPTION
I was experiencing crashes when using this transition in an existing `UINavigationController` with one or more `UIViewController`s on the stack. Now, an existing `UINavigationController` will work fine.

To reproduce the crash I was talking about, you can try this in the kitten demo:
1. Add a new `UIViewController` to the storyboard and make it the root view controller of the `UINavigationController`.
2. Add a `UIButton` to the new view controller and drag a `push` segue from that button to the `KittenCollectionViewController`.
3. Run the app and navigate between the 3 screens. I experienced crashes here.

Then try the same with this commit, and the navigation will work :]