### PR TITLE
Add UIKit include, needed for UI* types

### DIFF
--- a/ZoomTransition/ZoomTransitionProtocol.h
+++ b/ZoomTransition/ZoomTransitionProtocol.h
@@ -24,6 +24,7 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 //  SOFTWARE.
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 typedef void(^ZoomAnimationBlock)(UIImageView * animatedSnapshot, UIView * sourceView, UIView * destinationView);
 


### PR DESCRIPTION
The Pod does not build in Xcode 6.3 beta without include the UIKit headers, you should include these anyway as your header consumes the UI* types.