### PR TITLE
Support custom completion block.

### DIFF
--- a/ZoomTransition/UIView+Snapshotting.m
+++ b/ZoomTransition/UIView+Snapshotting.m
@@ -32,7 +32,7 @@
 {
     // Use pre iOS-7 snapshot API since we need to render views that are off-screen.
     // iOS 7 snapshot API allows us to snapshot only things on screen
-    UIGraphicsBeginImageContextWithOptions(self.bounds.size, self.opaque, 0);
+    UIGraphicsBeginImageContextWithOptions(self.bounds.size, YES, [UIScreen mainScreen].scale);
     CGContextRef ctx = UIGraphicsGetCurrentContext();
     [self.layer renderInContext:ctx];
     UIImage *snapshot = UIGraphicsGetImageFromCurrentImageContext();

--- a/ZoomTransition/ZoomTransitionProtocol.h
+++ b/ZoomTransition/ZoomTransitionProtocol.h
@@ -27,6 +27,7 @@
 #import <UIKit/UIKit.h>
 
 typedef void(^ZoomAnimationBlock)(UIImageView * animatedSnapshot, UIView * sourceView, UIView * destinationView);
+typedef void(^ZoomCompletionBlock)(UIImageView * animatedSnapshot, UIView * sourceView, UIView * destinationView, void(^completion)(void));
 
 /**
  ZoomTransitionProtocol should be implemented by UIViewControllers, that wish to participate in zoom transition.
@@ -61,6 +62,14 @@ typedef void(^ZoomAnimationBlock)(UIImageView * animatedSnapshot, UIView * sourc
  @return Animation block.
  */
 -(ZoomAnimationBlock)animationBlockForZoomTransition;
+
+
+/**
+ Custom animation block, that will be called inside UIView animateKeyFramesWithDuration:delay:options:animations:completion: method when the animation is completed.
+ 
+ @return Animation block.
+ */
+-(ZoomCompletionBlock)completionBlockForZoomTransition;
 
 
 /**


### PR DESCRIPTION
Added a completion block to support additional animations when the transition is finished.
Here's an example in Swift:
```swift
func animationBlockForZoomTransition() -> ZoomAnimationBlock! {
    return { (animatedSnapshot: UIImageView!, sourceView: UIView!, destinationView: UIView!) -> Void in
        animatedSnapshot.transform = CGAffineTransformMakeScale(1.02, 1.02)
    }
}

func completionBlockForZoomTransition() -> ZoomCompletionBlock! {
    return { (animatedSnapshot: UIImageView!, sourceView: UIView!, destinationView: UIView!, completion: (() -> Void)?) -> Void in
        UIView.animateWithDuration(0.2, animations: { () -> Void in
            animatedSnapshot.transform = CGAffineTransformIdentity
            }, completion: { (Bool) -> Void in
                if let completion = completion {
                    completion()
                }
        })
    }
}
```